### PR TITLE
Wrong command to launch container

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,5 +50,5 @@ mkdir ~/sbot-data
 docker run --name sbot \
    -d -v ~/sbot-data/:/root/.ssb/ 
    -e HOST="<hostname.yourdomain.tld>" 
-   -p 8008:8008 --restart always scuttlebot
+   -p 8008:8008 --restart always ktorn/docker-scuttlebot
 ```


### PR DESCRIPTION
The provided example doesn't work; you have to give the fully qualified image name